### PR TITLE
use ImportFrom

### DIFF
--- a/tseriesChaos/DESCRIPTION
+++ b/tseriesChaos/DESCRIPTION
@@ -10,7 +10,7 @@ LazyLoad: yes
 Description: Routines for the analysis of nonlinear time series. This
         work is largely inspired by the TISEAN project, by Rainer
         Hegger, Holger Kantz and Thomas Schreiber:
-        http://www.mpipks-dresden.mpg.de/~tisean/
+        http://www.mpipks-dresden.mpg.de/~tisean/ .
 Maintainer: Antonio Fabio Di Narzo <antonio.fabio@gmail.com>
 License: GPL-2
 Packaged: 2010-02-24 09:23:38 UTC; adinarzo

--- a/tseriesChaos/NAMESPACE
+++ b/tseriesChaos/NAMESPACE
@@ -19,3 +19,9 @@ print.false.nearest,
 plot.false.nearest)
 
 useDynLib(tseriesChaos)
+
+importFrom("grDevices", "gray")
+importFrom("deSolve", "lsoda")
+importFrom("graphics", "abline", "filled.contour", "lines", "plot")
+importFrom("stats", "as.ts", "dist", "end", "frequency", "lm", "sd", "lag",
+             "start", "time", "ts", "ts.intersect", "tsp", "window")


### PR DESCRIPTION
Hi Antonio! 

Hope you are doing well? So long we haven't talked!

There was a bug in tsDyn, when using tseriesChaos::embedd. Problem is embedd uses lag(), yes does not imports it. Then dplyr::lag() would overwrite it, and the function fail. I think this pull request should solve it! 

Bug:

```
library(tseriesChaos)
x <- window(rossler.ts, start=90)
xyz <- embedd(x, m=3, d=8)
library(dplyr)
xyz <- embedd(x, m=3, d=8)

```